### PR TITLE
Fixed type signatures of lambda parameters

### DIFF
--- a/lib/enumerable.ts
+++ b/lib/enumerable.ts
@@ -30,7 +30,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * var longestName = asEnumerable(fruits)
     *                  .Aggregate("banana", (longest, next) => next.Length > longest.Length ? next : longest, fruit => fruit.ToUpper());    
     */
-    Aggregate<A, B>(func: (A, T) => A, resultSelector?: (A) => B): B;
+    Aggregate<B>(func: (aggr: T, x: T) => T, resultSelector?: (aggr: T) => B): B;
 
     /**
     * Applies an accumulator function over a sequence.The specified seed value 
@@ -44,7 +44,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * var longestName = asEnumerable(fruits)
     *                  .Aggregate("banana", (longest, next) => next.Length > longest.Length ? next : longest, fruit => fruit.ToUpper());    
     */
-    Aggregate<A, B>(seed: A, func: (A, T) => A, resultSelector?: (A) => B): B;
+    Aggregate<A, B>(seed: A, func: (aggr: A, x: T) => A, resultSelector?: (aggr: A) => B): B;
 
     /**
     * Determines whether all elements of a sequence satisfy a condition.
@@ -53,7 +53,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e:boolean = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).All((a) => a > 0);
     */
-    All(predicate: (T) => Boolean): boolean;
+    All(predicate: (x: T) => Boolean): boolean;
 
     /** 
     * Determines whether a sequence contains any elements or if predicate is 
@@ -63,7 +63,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     * var unvaccinated = asEnumerable(pets).Any(p => p.Vaccinated == false);
     */
-    Any(predicate?: (T) => Boolean): boolean;
+    Any(predicate?: (x: T) => Boolean): boolean;
 
     /** 
     * Computes the average of a sequence of Number values that are obtained by 
@@ -72,7 +72,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable(['5', '6', '7']).Average(a=>eval(a));
     */
-    Average(func?: (T) => number): number;
+    Average(func?: (x: T) => number): number;
 
 
     /**
@@ -105,7 +105,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e:number = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Count((a) => a > 3)
     */
-    Count(predicate?: (T) => Boolean): number;
+    Count(predicate?: (x: T) => Boolean): number;
 
     /** 
     * Returns the elements of the specified sequence or the specified value in 
@@ -131,7 +131,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     enumerable(arrayOfObjects).Distinct(o => o.id);
     */
-    Distinct<V>(keySelector?: (T) => V): Enumerable<T>;
+    Distinct<V>(keySelector?: (x: T) => V): Enumerable<T>;
 
     /**
     * Returns the element at a specified index in a sequence. 
@@ -162,7 +162,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     *     asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Intersect([2,3,5]);
     *   // Will return 0, 1, 4, 6, 7
     */
-    Except<K>(other: Iterable<T>, keySelector?: (T) => K): Enumerable<T>;
+    Except<K>(other: Iterable<T>, keySelector?: (x: T) => K): Enumerable<T>;
 
     /**
     * Returns the first element in a sequence that satisfies a specified condition. 
@@ -171,7 +171,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).First(a => a > 2);
     */
-    First(predicate?: (T) => boolean): T;
+    First(predicate?: (x: T) => boolean): T;
 
     /**
     * Returns the first element of the sequence that satisfies a condition or a
@@ -180,7 +180,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).FirstOrDefault(a => a > 2);
     */
-    FirstOrDefault(predicate?: (T) => boolean): T;
+    FirstOrDefault(predicate?: (x: T) => boolean): T;
 
     /** 
     * Groups the elements of a sequence according to a specified key selector 
@@ -192,7 +192,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *   var e = asEnumerable(pets).GroupBy(pet => pet.Age, pet => pet)
     */
-    GroupBy<K, E, R>(selKey: (T) => K, selElement?: (T) => E, selResult?: (a: K, b: Iterable<E>) => R): Enumerable<R>;
+    GroupBy<K, E, R>(selKey: (x: T) => K, selElement?: (x: T) => E, selResult?: (a: K, b: Iterable<E>) => R): Enumerable<R>;
 
     /** 
     * Correlates the elements of two sequences based on equality of keys and groups the results. The default equality comparer is used to compare keys. 
@@ -209,7 +209,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     *               };
     *       });
     */
-    GroupJoin<I, K, R>(inner: Iterable<I>, outerKeySelector: (T) => K, innerKeySelector: (I) => K, resultSelector: (a: T, b: Iterable<I>) => R): Enumerable<R>;
+    GroupJoin<I, K, R>(inner: Iterable<I>, outerKeySelector: (a: T) => K, innerKeySelector: (b: I) => K, resultSelector: (a: T, b: Iterable<I>) => R): Enumerable<R>;
 
     /** 
     * Produces the intersection of two sequences. 
@@ -218,7 +218,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Intersect(asEnumerable([1, 3, 5, 11, 23, 44]));
     */
-    Intersect<K>(other: Iterable<T>, keySelector?: (T) => K): Enumerable<T>;
+    Intersect<K>(other: Iterable<T>, keySelector?: (x: T) => K): Enumerable<T>;
 
     /** 
     * Correlates the elements of two sequences based on matching keys. A specified IEqualityComparer<T> is used to compare keys. 
@@ -235,7 +235,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     *               return person.Name + " - " + pet.Name;
     *           });
     */
-    Join<I, K, R>(inner: Iterable<I>, oSelector: (T) => K, iSelector: (I) => K, transform: (T, I) => R): Enumerable<R>;
+    Join<I, K, R>(inner: Iterable<I>, oSelector: (o: T) => K, iSelector: (i: I) => K, transform: (o: T, i: I) => R): Enumerable<R>;
 
     /**	
     * Returns the last element of a sequence that satisfies a specified condition. 
@@ -244,7 +244,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Last();
     */
-    Last(predicate?: (T) => boolean): T;
+    Last(predicate?: (x: T) => boolean): T;
 
     /** 
     * Returns the last element of a sequence that satisfies a condition or a default value if no such element is found. 
@@ -252,7 +252,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).LastOrDefault();
     */
-    LastOrDefault(predicate?: (T) => boolean): T;
+    LastOrDefault(predicate?: (x: T) => boolean): T;
 
     /** 
     * Invokes a transform function on each element of a sequence and returns 
@@ -261,7 +261,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Max();
     */
-    Max(transform?: (T) => number): number;
+    Max(transform?: (x: T) => number): number;
 
     /** 
     * Invokes a transform function on each element of a sequence and returns the minimum Decimal value. 
@@ -269,7 +269,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Min()
     */
-    Min(transform?: (T) => number): number;
+    Min(transform?: (x: T) => number): number;
 
     /** 
     * Sorts the elements of a sequence in ascending order by using a specified  comparer. 
@@ -278,7 +278,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable(jsn).OrderBy(a=> a.name);
     */
-    OrderBy<K>(keySelect?: (T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
+    OrderBy<K>(keySelect?: (x: T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
 
     /** 
     * Sorts the elements of a sequence in descending order by using a specified comparer. 
@@ -287,7 +287,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable(jsn).OrderByDescending(a=> a.name);
     */
-    OrderByDescending<K>(keySelect?: (T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
+    OrderByDescending<K>(keySelect?: (x: T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
 
     /** 
     * Performs a subsequent ordering of the elements in a sequence in ascending order by using a specified comparer. 
@@ -299,7 +299,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     *                       .ThenBy(fruit=> fruit.charCodeAt(0))
     *                       .ThenBy(fruit=> fruit.charCodeAt(4));
     */
-    ThenBy<K>(keySelect?: (T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
+    ThenBy<K>(keySelect?: (x: T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
 
     /** 
     * Performs a subsequent ordering of the elements in a sequence in descending order by using a specified comparer. 
@@ -311,7 +311,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     *                       .ThenByDescending(fruit=> fruit.charCodeAt(0))
     *                       .ThenByDescending(fruit=> fruit.charCodeAt(4));
     */
-    ThenByDescending<K>(keySelect?: (T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
+    ThenByDescending<K>(keySelect?: (x: T) => K, equal?: (a: K, b: K) => number): Enumerable<T>;
 
     /** 
     * Returns count of numbers beginning from start  
@@ -344,7 +344,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
         var array = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Select((a, idx) => a * idx);
     */
-    Select<V>(transform: (T) => V): Enumerable<V>;
+    Select<V>(transform: (x: T) => V): Enumerable<V>;
 
     /**	
     * Projects each element of a sequence into a new form by incorporating the element's index. 
@@ -352,7 +352,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
         var array = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Select((a, idx) => a * idx);
     */
-    Select<V>(transform: (T, number) => V): Enumerable<V>;
+    Select<V>(transform: (x: T, index: number) => V): Enumerable<V>;
 
     /**
     * Projects each element of a sequence to an Iterable<T>, flattens the resulting sequences into one sequence, and invokes a result selector 
@@ -362,7 +362,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var iterable = asEnumerable(jsn).SelectMany(a => a.ids, b => b);
     */
-    SelectMany<S, V>(selector?: (T, number) => Iterable<S>, result?: (T, S) => V): Enumerable<V>;
+    SelectMany<S, V>(selector?: (x: T, index: number) => Iterable<S>, result?: (x: T, s: S) => V): Enumerable<V>;
 
     /**
     * Determines whether two sequences are equal by comparing their elements
@@ -380,7 +380,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([4]).Single();
     */
-    Single(predicate?: (T) => boolean): T;
+    Single(predicate?: (x: T) => boolean): T;
 
     /** 
     * Returns the only element of a sequence that satisfies a specified condition or a default value if no such element exists; this method 
@@ -389,7 +389,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([4]).SingleOrDefault();
     */
-    SingleOrDefault(predicate?: (T) => boolean): T;
+    SingleOrDefault(predicate?: (x: T) => boolean): T;
 
     /** 
     * Bypasses a specified number of elements in a sequence and then returns 
@@ -409,7 +409,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     enumerable.SkipWhile((amount, index) => amount > index * 1000);
     */
-    SkipWhile(predicate: (T, number) => boolean): Enumerable<T>;
+    SkipWhile(predicate: (x: T, i: number) => boolean): Enumerable<T>;
 
     /** 
     * Computes the sum of the sequence of Decimal values that are obtained by 
@@ -418,7 +418,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = enumerable.Sum();
     */
-    Sum(transform?: (T) => number): number;
+    Sum(transform?: (x: T) => number): number;
 
     /** 
     * Returns a specified number of contiguous elements from the start of a 
@@ -437,7 +437,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).TakeWhile(a=> a < 4);
     */
-    TakeWhile(predicate: (T, number) => boolean): Enumerable<T>;
+    TakeWhile(predicate: (x: T, i: number) => boolean): Enumerable<T>;
 
     /** 
     * Converts Iterable to Array<T> 
@@ -453,7 +453,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @param keySelector A function to extract a key from each element.
     * @param elementSelector A transform function to produce a result element value from each element.
     */
-    ToMap<TKey, TElement>(keySelector: (T) => TKey, elementSelector?: (T) => TElement): Map<TKey, TElement>;
+    ToMap<TKey, TElement>(keySelector: (x: T) => TKey, elementSelector?: (x: T) => TElement): Map<TKey, TElement>;
 
     /** 
     * Creates a Map< TKey, TValue > from an IEnumerable< T > according
@@ -462,7 +462,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @param keySelector A function to extract a key from each element.
     * @param elementSelector A transform function to produce a result element value from each element.
     */
-    ToDictionary<TKey, TElement>(keySelector: (T) => TKey, elementSelector?: (T) => TElement): Map<TKey, TElement>;
+    ToDictionary<TKey, TElement>(keySelector: (x: T) => TKey, elementSelector?: (x: T) => TElement): Map<TKey, TElement>;
 
     /**
     * Creates a Map< TKey, TValue > from an IEnumerable< T > according
@@ -481,7 +481,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable([0, 1, 2, 3, 4, 5, 6, 7]).Union([5,6,7,8,9]);
     */
-    Union<K>(second: Iterable<T>, keySelector?: (T) => K): Enumerable<T>;
+    Union<K>(second: Iterable<T>, keySelector?: (x: T) => K): Enumerable<T>;
 
     /**
     * Filters a sequence of values based on a predicate. 
@@ -489,7 +489,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     enumerable([0, 1, 2, 3, 4, 5, 6, 7]).Where(a => a % 2 == 1)
     */
-    Where(predicate: (T) => Boolean): Enumerable<T>;
+    Where(predicate: (x: T) => Boolean): Enumerable<T>;
 
     /**
     * Filters a sequence of values based on a predicate. 
@@ -498,7 +498,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     enumerable([0, 1, 2, 3, 4, 5, 6, 7]).Where((a,i) => a * i % 2 == 1)
     */
-    Where(predicate: (T, number) => Boolean): Enumerable<T>;
+    Where(predicate: (x: T, i: number) => Boolean): Enumerable<T>;
 
     /** 
     * Applies a specified function to the corresponding elements of two sequences, producing a sequence of the results. 
@@ -507,7 +507,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var e = asEnumerable(numbers).Zip(words, (first, second) => first + " " + second);
     */
-    Zip<V, Z>(second: Iterable<V>, func: (T, V) => Z): Enumerable<Z>;
+    Zip<V, Z>(second: Iterable<V>, func: (a: T, b: V) => Z): Enumerable<Z>;
 }
 
 


### PR DESCRIPTION
Fixes #21

I would consider turning noImplicitAny on for TS compiler, but it
requires additional effort.
