### PR TITLE
Add typescript 1.8.10 to fix compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "browserify": "^13.0.1",
     "chai": "^3.2.0",
     "jsmin": "^1.0.1",
-    "mocha": "^2.5.3"
+    "mocha": "^3.0.2"
   },
   "scripts": {
     "build:ts": "tsc",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "browserify": "^13.0.1",
     "chai": "^3.2.0",
     "jsmin": "^1.0.1",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
     "typescript": "^1.8.10"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "browserify": "^13.0.1",
     "chai": "^3.2.0",
     "jsmin": "^1.0.1",
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "typescript": "^1.8.10"
   },
   "scripts": {
     "build:ts": "tsc",


### PR DESCRIPTION
I got this error while running npm run build:

```
> npm run build:ts && npm run build:js &&  npm run build:min

> linq-es2015@2.4.5 build:ts C:\Users\azureuser\Documents\GitHub\_forks\LINQ
> tsc

error TS6047: Argument for '--target' option must be 'ES3', 'ES5', or 'ES6'.
error TS5023: Unknown compiler option 'noImplicitReturns'.

npm ERR! Windows_NT 10.0.10240
```

So I've added latest typescript to dev-dependencies.
