### PR TITLE
Improve type inference precision for Enumerable.Concat.

### DIFF
--- a/lib/enumerable.ts
+++ b/lib/enumerable.ts
@@ -102,7 +102,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     * @example
     *     var enumerable = asEnumerable([3, 4, 5, 6, 7]).Concat([1,2,8]);
     */
-    Concat<T>(second: Iterable<T>): Enumerable<T>;
+    Concat<V>(second: Iterable<V>): Enumerable<T|V>;
 
     /**
     * Determines whether a sequence contains a specified element by using a 

--- a/lib/generators.ts
+++ b/lib/generators.ts
@@ -248,7 +248,7 @@ export function* SelectMany<T, V, R>(target: Iterable<T>, selector: (x: T, i: nu
 }
 
 
-export function* Concat<T>(target: Iterable<T>, second: Iterable<T>) {
+export function* Concat<T, V>(target: Iterable<T>, second: Iterable<V>) {
     yield* target;
     yield* second;
 }

--- a/lib/linq.ts
+++ b/lib/linq.ts
@@ -504,8 +504,8 @@ class EnumerableImpl<T> implements Enumerable<T>, Iterable<T>, IEnumerable<T> {
     }
 
 
-    public Concat<T>(second: Iterable<T>): Enumerable<T> {
-        return new EnumerableImpl<T>(undefined, Generator.Concat, [this, second]);
+    public Concat<V>(second: Iterable<V>): Enumerable<T|V> {
+        return new EnumerableImpl<T|V>(undefined, Generator.Concat, [this, second]);
     }
 
 


### PR DESCRIPTION
fixes #44 