### PR TITLE
Implementation of IGrouping is actually an array

### DIFF
--- a/lib/enumerable.ts
+++ b/lib/enumerable.ts
@@ -609,7 +609,7 @@ export interface OrderedEnumerable<T> extends Enumerable<T>
 
 }
 
-export interface IGrouping<K, R> extends Enumerable<R> {
+export interface IGrouping<K, R> extends Array<R> {
     key: K
 }
 


### PR DESCRIPTION
I incorrectly thought IGrouping was implemented as Enumerable (which is how it is in .NET). However, after looking at it further at runtime, I see it's actually just an Array with a `key` property. I've updated the typing to reflect this.

My PR for linq-es5 also reflects this.