### PR TITLE
Fix #74: typing of GroupBy overload with result selector.

### DIFF
--- a/lib/enumerable.ts
+++ b/lib/enumerable.ts
@@ -217,7 +217,7 @@ export interface Enumerable<T> extends Iterable<T>, IEnumerable<T> {
     */
     GroupBy<K>(selKey: (x: T) => K): Enumerable<IGrouping<K, T>>;
     GroupBy<K, E>(selKey: (x: T) => K, selElement: (x: T) => E): Enumerable<IGrouping<K, E>>;
-    GroupBy<K, E, R>(selKey: (x: T) => K, selElement: (x: T) => E, selResult: (a: K, b: Iterable<E>) => R): Enumerable<IGrouping<K, R>>;
+    GroupBy<K, E, R>(selKey: (x: T) => K, selElement: (x: T) => E, selResult: (a: K, b: Iterable<E>) => R): Enumerable<R>;
 
     /** 
     * Correlates the elements of two sequences based on equality of keys and 

--- a/lib/linq.ts
+++ b/lib/linq.ts
@@ -60,7 +60,7 @@ function getRepeat<T>(value: T, count: number): Enumerable<T> {
 
 
 //-----------------------------------------------------------------------------
-//  Exoprts
+//  Exports
 //-----------------------------------------------------------------------------
 
 export {
@@ -533,7 +533,7 @@ class EnumerableImpl<T> implements Enumerable<T>, Iterable<T>, IEnumerable<T> {
     public GroupBy<K>(selKey: (x: T) => K): Enumerable<IGrouping<K, T>>;
     public GroupBy<K, E>(selKey: (x: T) => K, selElement: (x: T) => E): Enumerable<IGrouping<K, E>>;
     public GroupBy<K, E, R>(selKey: (x: T) => K, selElement: (x: T) => E = Constant.selfFn, 
-                            selResult: (a: K, b: Iterable<E>) => R = Constant.defGrouping): Enumerable<IGrouping<K, R>> {
+                            selResult: (a: K, b: Iterable<E>) => R = Constant.defGrouping): Enumerable<R> {
         let map: Map<K, Array<E>> = Constant.getKeyedMap(this, selKey, selElement);
         return new EnumerableImpl<R>(undefined, Generator.GroupBy, [map, selResult]) as any;
     }

--- a/test/deferred.ts
+++ b/test/deferred.ts
@@ -17,7 +17,7 @@ import {
 } from "./data";
 import {assert} from "chai";
 import Linq from "../lib/linq";
-
+import { Enumerable } from "../lib/enumerable";
 
 describe('Deferred Execution -', function () {
 
@@ -606,7 +606,7 @@ describe('Deferred Execution -', function () {
 
 
 
-    it('GroupBy() - Selector', function () {
+    it('GroupBy() - Element selector', function () {
         var iterable: any = Linq(pets).GroupBy(pet => pet.Age,
             pet => pet);
 
@@ -620,6 +620,24 @@ describe('Deferred Execution -', function () {
         result = iterator.next().value;
         assert.equal(1, result.key);
         assert.equal(1, result.length);
+        assert.isTrue(iterator.next().done);
+    });
+
+
+
+    it('GroupBy() - Result selector', function () {
+        var iterable: Enumerable<number> = Linq(pets).GroupBy(
+            pet => pet.Age,
+            pet => pet,
+            (age, group) => age);
+        
+        var iterator = iterable[Symbol.iterator]();
+        var result = iterator.next().value;
+        assert.equal(8, result);
+        result = iterator.next().value;
+        assert.equal(4, result);
+        result = iterator.next().value;
+        assert.equal(1, result);
         assert.isTrue(iterator.next().done);
     });
 


### PR DESCRIPTION
This pull request is for a fix for issue #74.

I have fixed the typing of the `GroupBy` overload with the result selector, and added a unit test to show successful assignation of that overload's result to an explicitly-typed variable.

It is also applicable to the `linq-es5` branch, but I presume that would be handled independently.

