### PR TITLE
Refactor ThenBy, ThenByDescending to be immutable when chaining them

### DIFF
--- a/lib/linq.ts
+++ b/lib/linq.ts
@@ -713,43 +713,32 @@ class OrderedLinq<T, K> extends EnumerableImpl<T> implements OrderedEnumerable<T
         return this._factory(this._factoryArg);
     }
 
-
     public ThenBy<K>(keySelect: (x: T) => K, equal?: (a: K, b: K) => number): OrderedEnumerable<T> {
-        if (!keySelect && !equal) return this;   
+        if (!keySelect && !equal) return this;
 
-        var compare = keySelect ? equal ? (a: any, b: any) => equal(keySelect(a), keySelect(b)) 
-                                        : (a: any, b: any) => Constant.defCompare(keySelect(a), keySelect(b)) 
-                                : equal;
-       
-        if (!this.comparer) {
-            this.comparer = compare;
-        } else {
-            let superEqual = this.comparer;
-            this.comparer = (a: any, b: any) => {
-                let result: number = superEqual(a, b);
-                return (0 != result) ? result : this.reversed ? -compare(a, b) : compare(a, b);
-            }
-        }
-        return this;
+        const compare = keySelect ? equal ? (a: any, b: any) => equal(keySelect(a), keySelect(b))
+                                          : (a: any, b: any) => Constant.defCompare(keySelect(a), keySelect(b))
+                                  : equal;
+
+        const superEqual = this.comparer;
+        const comparer = (!superEqual) ? compare
+                                       : (a: any, b: any) => superEqual(a, b) || (this.reversed ? -compare(a, b) : compare(a, b));
+
+        return new OrderedLinq<T, K>(this._target, this._factory, undefined, comparer, this.reversed);
     }
 
     public ThenByDescending<K>(keySelect: (x: T) => K, equal?: (a: K, b: K) => number): OrderedEnumerable<T> {
-        if (!keySelect && !equal) return this;   
+        if (!keySelect && !equal) return this;
 
-        var compare = keySelect ? equal ? (a: any, b: any) => equal(keySelect(a), keySelect(b)) 
-                                        : (a: any, b: any) => Constant.defCompare(keySelect(a), keySelect(b)) 
-                                : equal;
-       
-        if (!this.comparer) {
-            this.comparer = compare;
-        } else {
-            let superEqual = this.comparer;
-            this.comparer = (a: any, b: any) => {
-                let result: number = superEqual(a, b);
-                return (0 != result) ? result : this.reversed ? compare(a, b) : -compare(a, b);
-            }
-        }
-        return this;
+        const compare = keySelect ? equal ? (a: any, b: any) => equal(keySelect(a), keySelect(b))
+                                          : (a: any, b: any) => Constant.defCompare(keySelect(a), keySelect(b))
+                                  : equal;
+
+        const superEqual = this.comparer;
+        const comparer = (!superEqual) ? compare
+                                       : (a: any, b: any) => superEqual(a, b) || (this.reversed ? compare(a, b) : -compare(a, b));
+
+        return new OrderedLinq<T, K>(this._target, this._factory, undefined, comparer, this.reversed);
     }
 }
 

--- a/test/deferred.ts
+++ b/test/deferred.ts
@@ -205,7 +205,7 @@ describe('Deferred Execution -', function () {
 
         const expected = simpleArray.filter(a => a % 2 == 1);
         const actual = [...iterable];
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
     it('Where() - Index', function () {
@@ -213,7 +213,7 @@ describe('Deferred Execution -', function () {
 
         const expected = simpleArray.filter((a, i)  => i % 2 == 1);
         const actual = [...iterable];
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
 
@@ -225,7 +225,7 @@ describe('Deferred Execution -', function () {
 
         const expected = simpleArray.slice(7);
         const actual = [...iterable];
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
     it('SkipWhile()', function () {
@@ -260,7 +260,7 @@ describe('Deferred Execution -', function () {
 
         const expected = simpleArray.slice(0, 3);
         const actual = [...iterable];
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
     it('TakeWhile()', function () {
@@ -273,7 +273,7 @@ describe('Deferred Execution -', function () {
         }
 
         const actual = [...iterable];
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
 
@@ -478,9 +478,10 @@ describe('Deferred Execution -', function () {
         
     });
 
-    it('Join() - null key', function () {
+    it('Join() - ignore null key', function () {
         const nullPerson: { Name: string; } = null;
-        const expectedPeople = people.concat(nullPerson);
+        const expectedPeople = people.slice();
+        expectedPeople.push(nullPerson);
 
         const actual = Linq(expectedPeople).Join(
             pets,
@@ -492,7 +493,7 @@ describe('Deferred Execution -', function () {
             .filter(person => person != null)
             .map(person => pets.filter(pet => pet.Owner === person).map(pet => person.Name + " - " + pet.Name)));
 
-        assert.sameMembers(actual, expected);
+        assert.sameOrderedMembers(actual, expected);
     });
 
 


### PR DESCRIPTION
```ts
items.OrderBy(x => x.a).ThenByDescending(x => x.b).ThenBy(x => x.c).ThenByDescending(x => x.d)
```