### PR TITLE
Fix Union target

### DIFF
--- a/lib/linq.ts
+++ b/lib/linq.ts
@@ -658,7 +658,7 @@ class EnumerableImpl<T> implements Enumerable<T>, Iterable<T>, IEnumerable<T> {
 
 
     public Union<K>(second: Iterable<T>, keySelector: (x: T) => K = Constant.selfFn): Enumerable<T> {
-        var aggregate = [this._target, second];
+        var aggregate = [this, second];
         return new EnumerableImpl<T>(this, () => new Iterator.Union<T,K>((aggregate as any)[Symbol.iterator](), keySelector));
     }
 

--- a/test/deferred.ts
+++ b/test/deferred.ts
@@ -459,7 +459,22 @@ describe('Deferred Execution -', function () {
         assert.isTrue(iterator.next().done);
     });
 
-
+    it('Union() with Join()', function() {
+        var as = [{ a: 1, b: 1 }];
+        var bs = [{ b: 1, c: 1 }];
+        var bs2 = [{ b: 2, c: 2 }];
+        var iterable = Linq(as)
+          .Join(
+            bs,
+            (a) => a.b,
+            (b) => b.b,
+            (_, b) => b
+          ).Union(bs2);
+        var iterator = iterable[Symbol.iterator]();
+        assert.equal(bs[0], iterator.next().value);
+        assert.equal(bs2[0], iterator.next().value);
+        assert.isTrue(iterator.next().done);
+    });
 
 
     // Join


### PR DESCRIPTION
See included test, which succeeds in `master`
`Union` was being initialized with the current `_target`, effectively ignoring the previous operator.
I changed it to pass `this` instead.